### PR TITLE
Do not hardcode initial values for `RealDomain`s, `PDiagDomain`s, and `PSDDomain`s in the model

### DIFF
--- a/TeachingMaterial/DeepPumas/02_SciML.jl
+++ b/TeachingMaterial/DeepPumas/02_SciML.jl
@@ -492,7 +492,7 @@ model_softplus = @model begin
     CL ∈ RealDomain(; lower=0)
     Vc ∈ RealDomain(; lower=0)
     Ka ∈ RealDomain(; lower=0)
-    R₀ ∈ RealDomain(; lower=0, init=1e3)
+    R₀ ∈ RealDomain(; lower=0)
     σ ∈ RealDomain(; lower=0)
   end
   @init R = R₀
@@ -509,7 +509,7 @@ end
 fpm_softplus = fit(
   model_softplus,
   data_hard_scale,
-  init_params(model_softplus),
+  merge(init_params(model_softplus), (; R₀ = 1e3)),
   MAP(NaivePooled());
 )
 

--- a/TeachingMaterial/TimeToEvent/01-TimeToEvent.jl
+++ b/TeachingMaterial/TimeToEvent/01-TimeToEvent.jl
@@ -298,12 +298,12 @@ tte_exp_model = @model begin
   @param begin
     # Parameters of the Exponential(θ) distribution corresponding to the baseline hazard
     # Rate λ̄ = 1 / θ
-    λ̄ ∈ RealDomain(; lower=0, init=0.001)
+    λ̄ ∈ RealDomain(; lower=0)
     # NB we will denote with λ the final hazard of the model, after the proportional hazard correction
 
     # Parameters of the proportional hazard correction
     # Since we only have one covariate DOSE, we need a single parameter
-    β ∈ RealDomain(; init=0.001)
+    β ∈ RealDomain()
   end
 
   @covariates DOSE
@@ -340,14 +340,14 @@ tte_wei_model = @model begin
   @param begin
     # Parameters of the Weibull(α, θ) distribution corresponding to the baseline hazard
     # Rate λ̄ = 1 / θ where θ is the scale parameter
-    λ̄ ∈ RealDomain(; lower=0, init=0.001)
+    λ̄ ∈ RealDomain(; lower=0)
     # NB we will denote with λ the final hazard of the model, after the proportional hazard correction
     # Shape K = α (to use a name more commonly used in the biomedical modelling community)
-    K ∈ RealDomain(; lower=0, init=0.001)
+    K ∈ RealDomain(; lower=0)
 
     # Parameters of the proportional hazard correction
     # Since we only have one covariate DOSE, we need a single parameter
-    β ∈ RealDomain(; init=0.001)
+    β ∈ RealDomain()
   end
 
   @covariates DOSE
@@ -386,14 +386,14 @@ tte_gomp_model = @model begin
   @param begin
     # Parameters of the Gompertz distribution corresponding to the baseline hazard
     # Rate λ̄
-    λ̄ ∈ RealDomain(; lower=0, init=0.001)
+    λ̄ ∈ RealDomain(; lower=0)
     # NB we will denote with λ the final hazard of the model, after the proportional hazard correction
     # Shape K
-    K ∈ RealDomain(; lower=0, init=0.001)
+    K ∈ RealDomain(; lower=0)
 
     # Parameters of the proportional hazard correction
     # Since we only have one covariate DOSE, we need a single parameter
-    β ∈ RealDomain(; init=0.001)
+    β ∈ RealDomain()
   end
 
   @covariates DOSE
@@ -427,11 +427,11 @@ end
 
 ## Fit the models
 tte_single_exp_fit =
-  fit(tte_exp_model, tte_single_pop, init_params(tte_exp_model), NaivePooled());
+  fit(tte_exp_model, tte_single_pop, (; λ̄ = 0.001, β = 0.001), NaivePooled());
 tte_single_wei_fit =
-  fit(tte_wei_model, tte_single_pop, init_params(tte_wei_model), NaivePooled());
+  fit(tte_wei_model, tte_single_pop, (; λ̄ = 0.001, K = 0.001, β = 0.001), NaivePooled());
 tte_single_gomp_fit =
-  fit(tte_gomp_model, tte_single_pop, init_params(tte_gomp_model), NaivePooled());
+  fit(tte_gomp_model, tte_single_pop, (; λ̄ = 0.001, K = 0.001, β = 0.001), NaivePooled());
 
 ## Compare estimates
 compare_estimates(;

--- a/TeachingMaterial/population_pk/02-pk_model.jl
+++ b/TeachingMaterial/population_pk/02-pk_model.jl
@@ -27,25 +27,25 @@ warfarin_pkmodel = @model begin
     @param begin
         # Population PK Parameters
         "Clearance (L/h/70 kg)"
-        θCL   ∈ RealDomain(lower = 0.0, init = 0.134)
+        θCL   ∈ RealDomain(lower = 0.0)
         "Central Volume of Distribution (L/70 kg)"
-        θVC   ∈ RealDomain(lower = 0.0, init = 8.11)
+        θVC   ∈ RealDomain(lower = 0.0)
         "Absorption Half-Life (hr)"
-        θtabs ∈ RealDomain(lower = 0.0, init = 0.523)
+        θtabs ∈ RealDomain(lower = 0.0)
         "Absorption Lag Time (hr)"
-        θlag  ∈ RealDomain(lower = 0.0, init = 0.1)
+        θlag  ∈ RealDomain(lower = 0.0)
 
         # Inter-Individual Variability
         "Variance-Covariance for IIV in PK Parameters"
-        pk_Ω     ∈ PDiagDomain([0.09, 0.09])
+        pk_Ω     ∈ PDiagDomain(2)
         "Variance for IIV in Absorption Half-Life"
-        tabs_ω   ∈ RealDomain(lower = 0.0, init = 0.09)
+        tabs_ω   ∈ RealDomain(lower = 0.0)
         
         # Random Unexplained Variability
         "Proportional Error for Concentrations"
-        σ_prop   ∈ RealDomain(lower = 0.0, init = 0.00752)
+        σ_prop   ∈ RealDomain(lower = 0.0)
         "Additive Error for Concentrations (mg/L)"
-        σ_add    ∈ RealDomain(lower = 0.0, init = 0.0661)
+        σ_add    ∈ RealDomain(lower = 0.0)
     end
 
     # The @random block defines the distribution of individual random effects

--- a/TeachingMaterial/population_pk/03-pk_model_fitting.jl
+++ b/TeachingMaterial/population_pk/03-pk_model_fitting.jl
@@ -32,22 +32,17 @@ using Pumas, Serialization, Logging, PumasUtilities
 # -----------------------------------------------------------------------------
 # 2. INITIAL PARAMETER ESTIMATES
 # -----------------------------------------------------------------------------
-# Before fitting, we need starting values for all parameters
-# These come from the model's @param block initialization
-# Returns a NamedTuple
-initial_params = init_params(warfarin_pkmodel)
-
-# The initial parameters can also be defined outside the model, as follows: 
-initial_params = (
+# Before fitting, we need starting values for all parameters:
+warfarin_pkmodel_initial_params = (
     θCL = 0.134,
     θVC = 8.11,
     θtabs = 0.523,
     θlag = 0.1,
-    pk_Ω =  Diagonal([0.09, 0.09]),
+    pk_Ω = Diagonal([0.09, 0.09]),
     tabs_ω = 0.09,
     σ_prop = 0.00752,
-    σ_add = 0.0661 
-    )
+    σ_add = 0.0661,
+)
 
 # -----------------------------------------------------------------------------
 # 3. ESTIMATING PARAMETERS
@@ -58,10 +53,10 @@ initial_params = (
 # - Estimates individual random effects
 # - Computes the likelihood
 warfarin_pkmodel_fit = fit(
-    warfarin_pkmodel,              # The model we defined
-    pop_pk,                        # The population data
-    initial_params,                # Starting values
-    FOCE(),                        # Estimation method
+    warfarin_pkmodel,                 # The model we defined
+    pop_pk,                           # The population data
+    warfarin_pkmodel_initial_params,  # Starting values
+    FOCE(),                           # Estimation method
 ) 
 
 # Convergence trace: 
@@ -97,7 +92,7 @@ warfarin_pkmodel_fit = fit(
 warfarin_pkmodel_fit_fix = fit(
     warfarin_pkmodel,
     pop_pk,
-    (; initial_params..., tabs_ω = 0.5), # Replace initial value for tabs_ω by 0.5 
+    merge(warfarin_pkmodel_initial_params, (; tabs_ω = 0.5)), # Replace initial value for tabs_ω by 0.5 
     FOCE(),
     constantcoef = (:tabs_ω,),  # Fix the tabs_ω parameter
 )

--- a/TeachingMaterial/population_pkpd/02-pkpd_model.jl
+++ b/TeachingMaterial/population_pkpd/02-pkpd_model.jl
@@ -35,37 +35,37 @@ warfarin_model = @model begin
     @param begin
         # Population PK Parameters
         "Clearance (L/h/70 kg)"
-        θCL   ∈ RealDomain(lower = 0.0, init = 0.134)
+        θCL   ∈ RealDomain(lower = 0.0)
         "Central Volume of Distribution (L/70 kg)"
-        θVC   ∈ RealDomain(lower = 0.0, init = 8.11)
+        θVC   ∈ RealDomain(lower = 0.0)
         "Absorption Half-Life (hr)"
-        θtabs ∈ RealDomain(lower = 0.0, init = 0.523)
+        θtabs ∈ RealDomain(lower = 0.0)
         "Absorption Lag Time (hr)"
-        θlag  ∈ RealDomain(lower = 0.0, init = 0.1)
+        θlag  ∈ RealDomain(lower = 0.0)
 
         # Population PD Parameters
         "Baseline Prothrombin Complex Activity"
-        θBASE ∈ RealDomain(init = 90.0)
+        θBASE ∈ RealDomain()
         "Maximum drug effect"
-        θEMAX ∈ RealDomain(lower = 0.0, upper = 1.0, init = 0.1)
+        θEMAX ∈ RealDomain(lower = 0.0, upper = 1.0)
         "Half-maximal concentration (mg/L)"
-        θEC50 ∈ RealDomain(lower = 0.0, init = 2.0)
+        θEC50 ∈ RealDomain(lower = 0.0)
         "Half-life of turnover (hr)"
-        θTHALF ∈ RealDomain(lower = 0.0, init = 14.0)
+        θTHALF ∈ RealDomain(lower = 0.0)
 
         # Inter-Individual Variability
         "Variance-Covariance for IIV in PK Parameters"
-        pk_Ω     ∈ PDiagDomain([0.09, 0.09])
+        pk_Ω     ∈ PDiagDomain(2)
         "Variance for IIV in Absorption Half-Life"
-        tabs_ω   ∈ RealDomain(lower = 0.0, init = 0.09)
-        
+        tabs_ω   ∈ RealDomain(lower = 0.0)
+
         # Random Unexplained Variability
         "Proportional Error for Concentrations"
-        σ_prop   ∈ RealDomain(lower = 0.0, init = 0.09)
+        σ_prop   ∈ RealDomain(lower = 0.0)
         "Additive Error for Concentrations (mg/L)"
-        σ_add    ∈ RealDomain(lower = 0.0, init = 0.09)
+        σ_add    ∈ RealDomain(lower = 0.0)
         "Proportional Residual Error for PCA"
-        σ_proppd ∈ RealDomain(lower = 0.0, init = 0.09)
+        σ_proppd ∈ RealDomain(lower = 0.0)
     end
 
     # The @random block defines the distribution of individual random effects

--- a/TeachingMaterial/population_pkpd/03-pkpd_model_fitting.jl
+++ b/TeachingMaterial/population_pkpd/03-pkpd_model_fitting.jl
@@ -32,10 +32,22 @@ using Pumas, Serialization, Logging, PumasUtilities
 # -----------------------------------------------------------------------------
 # 2. INITIAL PARAMETER ESTIMATES
 # -----------------------------------------------------------------------------
-# Before fitting, we need starting values for all parameters
-# These come from the model's @param block initialization
-# Returns a NamedTuple
-initial_params = init_params(warfarin_model)
+# Before fitting, we need starting values for all parameters:
+warfarin_model_initial_params = (
+    θCL = 0.134,
+    θVC = 8.11,
+    θtabs = 0.523,
+    θlag = 0.1,
+    θBASE = 90.0,
+    θEMAX = 0.1,
+    θEC50 = 2.0,
+    θTHALF = 14.0,
+    pk_Ω = Diagonal([0.09, 0.09]),
+    tabs_ω = 0.09,
+    σ_prop = 0.09,
+    σ_add = 0.09,
+    σ_proppd = 0.09,
+)
 
 # -----------------------------------------------------------------------------
 # 3. ESTIMATING PARAMETERS
@@ -46,10 +58,10 @@ initial_params = init_params(warfarin_model)
 # - Estimates individual random effects
 # - Computes the likelihood
 warfarin_model_fit = fit(
-    warfarin_model,              # The model we defined
+    warfarin_model,                  # The model we defined
     pop_pkpd,                        # The population data
-    initial_params,                # Starting values
-    FOCE(),                        # Estimation method
+    warfarin_model_initial_params,   # Starting values
+    FOCE(),                          # Estimation method
 ) 
 
 # Convergence trace: 


### PR DESCRIPTION
As discussed yesterday, we'd rather like to encourage defining initial parameters for `fit` outside of the model, so it seems reasonable to change the workshop materials.